### PR TITLE
feat: support customize wakatime server url

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,0 @@
-export const BASE_URL = "https://api.wakatime.com/api/v1/"

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,11 @@ async function main() {
   initSetting()
 
   if (!logseq.settings?.apiKey) {
-    logseq.UI.showMsg(`Please set the API key first`, "error")
+    logseq.UI.showMsg(`Please set the Wakatime API key first`, "error")
+  }
+
+  if (logseq.settings?.url.trim() === '') {
+    logseq.UI.showMsg(`Please set the Wakatime host first`, "error")
   }
 
   logseq.onSettingsChanged((current) => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,8 +1,8 @@
-import { BASE_URL } from './config'
 
 const request = async (url: string, { method = 'GET', headers = {}, params = {}, body = {} } = {}) => {
-  if (!logseq.settings?.apiKey) return
+  if (!logseq.settings?.apiKey && !logseq.settings?.url) return
   const apiKey = btoa(logseq.settings?.apiKey);
+  const baseUrl = logseq.settings?.url.endsWith('/') ? logseq.settings?.url : `${logseq.settings?.url}/`
 
   const defaultHeaders = {
     'Content-Type': 'application/json',
@@ -19,7 +19,7 @@ const request = async (url: string, { method = 'GET', headers = {}, params = {},
   };
 
   try {
-    const response = await fetch(`${BASE_URL}${fullUrl}`, config);
+    const response = await fetch(`${baseUrl}${fullUrl}`, config);
 
     if (!response.ok) {
       throw new Error(`HTTP error! Status: ${response.status}`);

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -13,6 +13,13 @@ export const initSetting = () => {
       title: "Interval",
       description: "The interval time for sending a heartbeat, Unit: second.",
       default: 5,
+    },
+    {
+      key: 'url',
+      type: 'string',
+      title: 'Wakatime URL',
+      description: 'The URL of Wakatime',
+      default: 'https://api.wakatime.com/api/v1/'
     }
   ])
 }


### PR DESCRIPTION
This feature intends to support 3rd part wakatime server implements(like wakapi)

I added a new setting item called `url`, and the default is the official server.

You can see it works with wakapi below:
![image](https://github.com/user-attachments/assets/3a25a7a4-5204-4132-a8e6-dea0f64e2ff2)
